### PR TITLE
feat: Update data fetcher to use provider abstraction

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -2,7 +2,7 @@
 
 import * as core from "@actions/core";
 import { writeFile, mkdir } from "fs/promises";
-import type { FetchDataResult } from "../github/data/fetcher";
+import type { FetchDataResult } from "../github/data/fetcher-unified";
 import {
   formatContext,
   formatBody,

--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -16,7 +16,7 @@ import { configureGitAuth } from "../github/operations/git-config";
 import { prepareMcpConfig } from "../mcp/install-mcp-server";
 import { createPrompt } from "../create-prompt";
 import { createOctokit } from "../github/api/client";
-import { fetchGitHubData } from "../github/data/fetcher";
+import { fetchForgeData } from "../github/data/fetcher-unified";
 import { parseGitHubContext } from "../github/context";
 
 async function run() {
@@ -55,8 +55,7 @@ async function run() {
     const commentId = commentData.id;
 
     // Step 7: Fetch GitHub data (once for both branch setup and prompt creation)
-    const githubData = await fetchGitHubData({
-      octokits: octokit,
+    const githubData = await fetchForgeData({
       repository: `${context.repository.owner}/${context.repository.repo}`,
       prNumber: context.entityNumber.toString(),
       isPR: context.isPR,

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -5,7 +5,7 @@ import type {
   GitHubFile,
   GitHubReview,
 } from "../types";
-import type { GitHubFileWithSHA } from "./fetcher";
+import type { GitHubFileWithSHA } from "./fetcher-unified";
 import { sanitizeContent } from "../utils/sanitizer";
 
 export function formatContext(

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -11,7 +11,7 @@ import * as core from "@actions/core";
 import type { ParsedGitHubContext } from "../context";
 import type { GitHubPullRequest } from "../types";
 import type { Octokits } from "../api/client";
-import type { FetchDataResult } from "../data/fetcher";
+import type { FetchDataResult } from "../data/fetcher-unified";
 
 export type BranchInfo = {
   baseBranch: string;

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -13,7 +13,7 @@ import type {
   GitHubComment,
   GitHubFile,
 } from "../src/github/types";
-import type { GitHubFileWithSHA } from "../src/github/data/fetcher";
+import type { GitHubFileWithSHA } from "../src/github/data/fetcher-unified";
 
 describe("formatContext", () => {
   test("formats PR context correctly", () => {


### PR DESCRIPTION
## Summary

Phase 2 最終タスク：既存のデータフェッチャーをプロバイダー抽象化に更新

- 直接的なGitHub API呼び出しを統合されたプロバイダーインターフェースに置換
- `fetcher` から `fetcher-unified` へのインポート更新
- 全コンポーネントがプロバイダー抽象化レイヤーを使用
- 既存機能との後方互換性を維持
- GitHub と Forgejo プロバイダー間のシームレスな切り替えを実現

## Changes Made

1. **prepare.ts**: `fetchGitHubData` を `fetchForgeData` に更新
2. **create-prompt/index.ts**: `FetchDataResult` インポートを統合版に更新
3. **branch.ts**: `FetchDataResult` インポートを統合版に更新
4. **formatter.ts**: `GitHubFileWithSHA` インポートを統合版に更新
5. **data-formatter.test.ts**: テストでのインポートを統合版に更新

## Test Results

- 全テストが成功 (108個のテストが通過)
- TypeScript型チェックが通過
- フォーマットチェックが通過

## Impact

これにより、Phase 2の全タスクが完了し、統一されたプロバイダーインターフェースを通じて GitHub と Forgejo の両方に対応できるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)